### PR TITLE
Refactor web3 init, improve contract interactions and UI, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,76 @@
-# payroll
+# Payroll DApp
 
-It is common for the payment to be overdue or missed when working for small business and contract employment. A payroll system based on Ethereum can be a solution resolving this issue.
+A lightweight Ethereum payroll system for small teams and contractors.
 
 ## Features
 
-* Add/Update/Delete employees
-* Add fund to the contract
-* Ensure employees get paid on time
+- Add, update, and remove employees
+- Fund the payroll contract from an employer account
+- Let employees withdraw salary on payday
+- Show contract-level and account-level payroll metrics
 
-## Get Started
+## Project structure
 
-1. Install dependencies `npm install -g truffle ethereumjs-testrpc`
-1. Install [Metamask](https://metamask.io/)
-1. Run `testrpc`
-1. Add first account in testrpc to Metamask by importing private key
-1. Run `truffle compile` in the project directory
-1. `truffle migrate`
-1. `npm run start`
+- `contracts/`: Solidity contracts and payroll business rules
+- `migrations/`: Truffle deployment scripts
+- `src/`: React UI and web3 integration
+- `test/`: Solidity and JavaScript tests
 
-## Why this is better than traditional system
+## Local development (recommended)
 
-* Get rid of costly third party HR management
-* Make employees be able to get payment ontime
+### Prerequisites
+
+- Node.js 18+ (or the latest active LTS)
+- npm 9+
+- Ganache (GUI or CLI)
+- MetaMask
+
+### 1) Install dependencies
+
+```bash
+npm install
+```
+
+If your environment cannot access GitHub over SSH and `npm install` fails with `ssh://git@github.com/...`, force Git to use HTTPS:
+
+```bash
+git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+```
+
+Then run `npm install` again.
+
+### 2) Run a local chain
+
+Start Ganache and keep it running on `http://localhost:8545`.
+
+### 3) Deploy contracts
+
+```bash
+truffle compile
+truffle migrate --reset
+```
+
+### 4) Start the app
+
+```bash
+npm run start
+```
+
+## Best-practice notes
+
+- Use a dedicated wallet/account for local development.
+- Never import production private keys into a local test wallet.
+- Reset and re-migrate contracts after changing Solidity storage or constructor logic.
+- Keep UI values in ETH for display, but persist contract values in wei.
+
+## Testing
+
+```bash
+npm test -- --watch=false
+```
+
+For smart contract flows, also run Truffle tests:
+
+```bash
+truffle test
+```

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PayrollContract from '../build/contracts/Payroll.json'
 import getWeb3 from './utils/getWeb3'
 
-import { Layout, Menu, Spin, Alert } from 'antd';
+import { Layout, Menu, Spin, Alert, message } from 'antd';
 
 import Employer from './components/Employer';
 import Employee from './components/Employee';
@@ -17,73 +17,69 @@ class App extends Component {
     super(props)
 
     this.state = {
-      storageValue: 0,
       web3: null,
-      mode: 'employer'
+      mode: 'employer',
+      loadingContract: true
     }
   }
 
-  componentWillMount() {
-    // Get network provider and web3 instance.
-    // See utils/getWeb3 for more info.
-
+  componentDidMount() {
     getWeb3
-    .then(results => {
-      this.setState({
-        web3: results.web3
+      .then(results => {
+        this.setState({ web3: results.web3 });
+        this.instantiateContract(results.web3);
       })
-
-      // Instantiate contract once web3 provided.
-      this.instantiateContract()
-    })
-    .catch(() => {
-      console.log('Error finding web3.')
-    })
+      .catch(() => {
+        message.error('Unable to initialize web3 provider.');
+        this.setState({ loadingContract: false });
+      })
   }
 
-  instantiateContract() {
-    /*
-     * SMART CONTRACT EXAMPLE
-     *
-     * Normally these functions would be called in the context of a
-     * state management library, but for convenience I've placed them here.
-     */
-
+  instantiateContract(web3) {
     const contract = require('truffle-contract')
     const Payroll = contract(PayrollContract)
-    Payroll.setProvider(this.state.web3.currentProvider)
+    Payroll.setProvider(web3.currentProvider)
 
-    // Declaring this for later so we can chain functions on Payroll.
-    var PayrollInstance
+    web3.eth.getAccounts((error, accounts) => {
+      if (error || !accounts || !accounts.length) {
+        message.error('No Ethereum account is available.');
+        this.setState({ loadingContract: false });
+        return;
+      }
 
-    // Get accounts.
-    this.state.web3.eth.getAccounts((error, accounts) => {
-      this.setState({
-        account: accounts[0],
-      });
+      const account = accounts[0];
+      this.setState({ account });
+
       Payroll.deployed().then((instance) => {
-        PayrollInstance = instance
         this.setState({
-          payroll: instance
+          payroll: instance,
+          loadingContract: false
         });
-      })
+      }).catch(() => {
+        message.error('Unable to connect to deployed Payroll contract.');
+        this.setState({ loadingContract: false });
+      });
     })
   }
 
-  onSelectTab = ({key}) => {
+  onSelectTab = ({ key }) => {
     this.setState({
       mode: key
     });
   }
 
   renderContent = () => {
-    const { account, payroll, web3, mode } = this.state;
+    const { account, payroll, web3, mode, loadingContract } = this.state;
 
-    if (!payroll) {
+    if (loadingContract) {
       return <Spin tip="Loading..." />;
     }
 
-    switch(mode) {
+    if (!payroll) {
+      return <Alert message="Payroll contract is unavailable." type="error" showIcon />;
+    }
+
+    switch (mode) {
       case 'employer':
         return <Employer account={account} payroll={payroll} web3={web3} />
       case 'employee':

--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,17 @@ class App extends Component {
       })
   }
 
-  instantiateContract(web3) {
+  async instantiateContract(web3) {
+    if (window.ethereum && window.ethereum.request) {
+      try {
+        await window.ethereum.request({ method: 'eth_requestAccounts' });
+      } catch (error) {
+        message.error('Wallet access is required to continue.');
+        this.setState({ loadingContract: false });
+        return;
+      }
+    }
+
     const contract = require('truffle-contract')
     const Payroll = contract(PayrollContract)
     Payroll.setProvider(web3.currentProvider)

--- a/src/components/Common.js
+++ b/src/components/Common.js
@@ -1,36 +1,39 @@
 import React, { Component } from 'react'
-import { Card, Col, Row } from 'antd';
+import { Card, Col, Row, message } from 'antd';
 
 class Common extends Component {
   constructor(props) {
     super(props);
 
     this.state = {};
+    this.watchers = [];
   }
 
   componentDidMount() {
-    const { payroll, web3 } = this.props;
-    const updateInfo = (error, result) => {
+    const { payroll } = this.props;
+    const updateInfo = (error) => {
       if (!error) {
         this.checkInfo();
       }
     }
 
-    this.newFund = payroll.NewFund(updateInfo);
-    this.getPaid = payroll.GetPaid(updateInfo);
-    this.newEmployee = payroll.NewEmployee(updateInfo);
-    this.updateEmployee = payroll.UpdateEmployee(updateInfo);
-    this.removeEmployee = payroll.RemoveEmployee(updateInfo);
+    this.watchers = [
+      payroll.NewFund(updateInfo),
+      payroll.GetPaid(updateInfo),
+      payroll.NewEmployee(updateInfo),
+      payroll.UpdateEmployee(updateInfo),
+      payroll.RemoveEmployee(updateInfo)
+    ];
 
     this.checkInfo();
   }
 
   componentWillUnmount() {
-    this.newFund.stopWatching();
-    this.getPaid.stopWatching();
-    this.newEmployee.stopWatching();
-    this.updateEmployee.stopWatching();
-    this.removeEmployee.stopWatching();
+    this.watchers.forEach((watcher) => {
+      if (watcher && watcher.stopWatching) {
+        watcher.stopWatching();
+      }
+    });
   }
 
   checkInfo = () => {
@@ -39,10 +42,12 @@ class Common extends Component {
       from: account,
     }).then((result) => {
       this.setState({
-        balance: web3.fromWei(result[0].toNumber()),
+        balance: web3.fromWei(result[0], 'ether').toString(10),
         runway: result[1].toNumber(),
         employeeCount: result[2].toNumber()
       })
+    }).catch(() => {
+      message.error('Unable to refresh contract info.');
     });
   }
 

--- a/src/components/Employee.js
+++ b/src/components/Employee.js
@@ -3,10 +3,12 @@ import { Card, Col, Row, Layout, Alert, message, Button } from 'antd';
 
 import Common from './Common';
 
-class Employer extends Component {
+class Employee extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      loading: true
+    };
   }
 
   componentDidMount() {
@@ -19,14 +21,22 @@ class Employer extends Component {
       from: account,
     }).then((result) => {
       this.setState({
-        salary: web3.fromWei(result[1].toNumber()),
-        lastPaidDate: new Date(result[2].toNumber() * 1000).toString()
+        salary: web3.fromWei(result[1], 'ether').toString(10),
+        lastPaidDate: new Date(result[2].toNumber() * 1000).toString(),
+        loading: false
       });
+    }).catch(() => {
+      message.error('Unable to fetch employee details.');
+      this.setState({ loading: false });
     });
 
     web3.eth.getBalance(account, (err, result) => {
+      if (err) {
+        return;
+      }
+
       this.setState({
-        balance: web3.fromWei(result.toNumber())
+        balance: web3.fromWei(result, 'ether').toString(10)
       });
     });
   }
@@ -35,16 +45,23 @@ class Employer extends Component {
     const { payroll, account } = this.props;
     payroll.getPaid({
       from: account,
-    }).then((result) => {
-      message.info(`You have been paid`);
+    }).then(() => {
+      message.info('You have been paid');
+      this.checkEmployee();
+    }).catch(() => {
+      message.error('Unable to withdraw salary right now.');
     });
   }
 
   renderContent() {
-    const { salary, lastPaidDate, balance } = this.state;
+    const { salary, lastPaidDate, balance, loading } = this.state;
+
+    if (loading) {
+      return <Alert message="Loading employee info..." type="info" showIcon />;
+    }
 
     if (!salary || salary === '0') {
-      return   <Alert message="You are not employee" type="error" showIcon />;
+      return <Alert message="You are not employee" type="error" showIcon />;
     }
 
     return (
@@ -80,9 +97,9 @@ class Employer extends Component {
         <Common account={account} payroll={payroll} web3={web3} />
         <h2>Personal info</h2>
         {this.renderContent()}
-      </Layout >
+      </Layout>
     );
   }
 }
 
-export default Employer
+export default Employee

--- a/src/components/EmployeeList.js
+++ b/src/components/EmployeeList.js
@@ -5,7 +5,7 @@ import EditableCell from './EditableCell';
 
 const FormItem = Form.Item;
 
-const columns = [{
+const baseColumns = [{
   title: 'Address',
   dataIndex: 'address',
   key: 'address',
@@ -30,38 +30,29 @@ class EmployeeList extends Component {
     this.state = {
       loading: true,
       employees: [],
-      showModal: false
+      showModal: false,
+      address: '',
+      salary: undefined
     };
-
-    columns[1].render = (text, record) => (
-      <EditableCell
-        value={text}
-        onChange={ this.updateEmployee.bind(this, record.address) }
-      />
-    );
-
-    columns[3].render = (text, record) => (
-      <Popconfirm title="Are you sure to delete?" onConfirm={() => this.removeEmployee(record.address)}>
-        <a href="#">Delete</a>
-      </Popconfirm>
-    );
   }
 
   componentDidMount() {
-    const { payroll, account, web3 } = this.props;
-    payroll.checkInfo.call({
-      from: account
-    }).then((result) => {
-      const employeeCount = result[2].toNumber();
+    const { payroll, account } = this.props;
+    payroll.checkInfo.call({ from: account })
+      .then((result) => {
+        const employeeCount = result[2].toNumber();
 
-      if (employeeCount === 0) {
-        this.setState({loading: false});
-        return;
-      }
+        if (employeeCount === 0) {
+          this.setState({ loading: false });
+          return;
+        }
 
-      this.loadEmployees(employeeCount);
-    });
-
+        this.loadEmployees(employeeCount);
+      })
+      .catch(() => {
+        message.error('Unable to load employees.');
+        this.setState({ loading: false });
+      });
   }
 
   loadEmployees(employeeCount) {
@@ -79,20 +70,25 @@ class EmployeeList extends Component {
         const employees = values.map(value => ({
           key: value[0],
           address: value[0],
-          salary: web3.fromWei(value[1].toNumber()),
+          salary: web3.fromWei(value[1], 'ether').toString(10),
           lastPaidDay: new Date(value[2].toNumber() * 1000).toString()
         }));
 
         this.setState({
           employees,
           loading: false
-        })
+        });
+      })
+      .catch(() => {
+        message.error('Unable to load employees.');
+        this.setState({ loading: false });
       });
   }
 
   addEmployee = () => {
     const { payroll, account } = this.props;
     const { address, salary, employees } = this.state;
+
     payroll.addEmployee(address, salary, {
       from: account,
     }).then(() => {
@@ -101,27 +97,33 @@ class EmployeeList extends Component {
         salary,
         key: address,
         lastPaidDay: new Date().toString()
-      }
+      };
 
       this.setState({
         address: '',
-        salary: '',
+        salary: undefined,
         showModal: false,
         employees: employees.concat([newEmployee])
       });
+    }).catch(() => {
+      message.error('Unable to add employee.');
     });
   }
 
   updateEmployee = (address, salary) => {
     const { payroll, account } = this.props;
     const { employees } = this.state;
+
     payroll.updateEmployee(address, salary, {
       from: account,
     }).then(() => {
       this.setState({
         employees: employees.map((employee) => {
           if (employee.address === address) {
-            employee.salary = salary;
+            return {
+              ...employee,
+              salary
+            };
           }
 
           return employee;
@@ -135,10 +137,11 @@ class EmployeeList extends Component {
   removeEmployee = (employeeId) => {
     const { payroll, account } = this.props;
     const { employees } = this.state;
+
     payroll.removeEmployee(employeeId, {
       from: account,
-    }).then((result) => {
-       this.setState({
+    }).then(() => {
+      this.setState({
         employees: employees.filter(employee => employee.address !== employeeId)
       });
     }).catch(() => {
@@ -147,39 +150,57 @@ class EmployeeList extends Component {
   }
 
   renderModal() {
-      return (
+    const { address, salary, showModal } = this.state;
+
+    return (
       <Modal
-          title="Add employee"
-          visible={this.state.showModal}
-          onOk={this.addEmployee}
-          onCancel={() => this.setState({showModal: false})}
+        title="Add employee"
+        visible={showModal}
+        onOk={this.addEmployee}
+        onCancel={() => this.setState({ showModal: false })}
       >
         <Form>
           <FormItem label="Address">
             <Input
-              onChange={ev => this.setState({address: ev.target.value})}
+              value={address}
+              onChange={ev => this.setState({ address: ev.target.value })}
             />
           </FormItem>
 
           <FormItem label="Salary">
             <InputNumber
               min={1}
-              onChange={salary => this.setState({salary})}
+              value={salary}
+              onChange={nextSalary => this.setState({ salary: nextSalary })}
             />
           </FormItem>
         </Form>
       </Modal>
     );
-
   }
 
   render() {
     const { loading, employees } = this.state;
+
+    const columns = baseColumns.map(column => ({ ...column }));
+    columns[1].render = (text, record) => (
+      <EditableCell
+        value={text}
+        onChange={this.updateEmployee.bind(this, record.address)}
+      />
+    );
+
+    columns[3].render = (text, record) => (
+      <Popconfirm title="Are you sure to delete?" onConfirm={() => this.removeEmployee(record.address)}>
+        <Button type="link">Delete</Button>
+      </Popconfirm>
+    );
+
     return (
       <div>
         <Button
           type="primary"
-          onClick={() => this.setState({showModal: true})}
+          onClick={() => this.setState({ showModal: true })}
         >
           Add employee
         </Button>

--- a/src/components/Employer.js
+++ b/src/components/Employer.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Layout, Menu, Alert } from 'antd';
+import { Layout, Menu, Alert, message } from 'antd';
 
 import Fund from './Fund';
 import EmployeeList from './EmployeeList';
@@ -23,7 +23,9 @@ class Employer extends Component {
       this.setState({
         owner: result
       });
-    })
+    }).catch(() => {
+      message.error('Unable to verify employer permissions.');
+    });
   }
 
   onSelectTab = ({key}) => {
@@ -45,6 +47,8 @@ class Employer extends Component {
         return <Fund account={account} payroll={payroll} web3={web3} />
       case 'employees':
         return <EmployeeList account={account} payroll={payroll} web3={web3} />
+      default:
+        return <Alert message="Please choose an employer mode" type="info" showIcon />
     }
   }
 

--- a/src/components/Fund.js
+++ b/src/components/Fund.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Form, InputNumber, Button } from 'antd';
+import { Form, InputNumber, Button, message } from 'antd';
 
 import Common from './Common';
 
@@ -9,20 +9,34 @@ class Fund extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {};
+    this.state = {
+      fund: undefined,
+      submitting: false
+    };
   }
 
   handleSubmit = (ev) => {
     ev.preventDefault();
     const { payroll, account, web3 } = this.props;
+    const { fund } = this.state;
+
+    this.setState({ submitting: true });
     payroll.addFund({
       from: account,
-      value: web3.toWei(this.state.fund)
+      value: web3.toWei(fund)
+    }).then(() => {
+      message.success('Fund added successfully.');
+      this.setState({ fund: undefined, submitting: false });
+    }).catch(() => {
+      message.error('Unable to add fund.');
+      this.setState({ submitting: false });
     });
   }
 
   render() {
     const { account, payroll, web3 } = this.props;
+    const { fund, submitting } = this.state;
+
     return (
       <div>
         <Common account={account} payroll={payroll} web3={web3} />
@@ -31,14 +45,16 @@ class Fund extends Component {
           <FormItem>
             <InputNumber
               min={1}
-              onChange={fund => this.setState({fund})}
+              value={fund}
+              onChange={nextFund => this.setState({ fund: nextFund })}
             />
           </FormItem>
           <FormItem>
             <Button
               type="primary"
               htmlType="submit"
-              disabled={!this.state.fund}
+              loading={submitting}
+              disabled={!fund || submitting}
             >
               Add fund
             </Button>

--- a/src/utils/getWeb3.js
+++ b/src/utils/getWeb3.js
@@ -30,7 +30,12 @@ const getWeb3 = new Promise((resolve, reject) => {
     return;
   }
 
-  window.addEventListener('load', initializeWeb3);
+  const onLoad = () => {
+    window.removeEventListener('load', onLoad);
+    initializeWeb3();
+  };
+
+  window.addEventListener('load', onLoad);
 });
 
 export default getWeb3

--- a/src/utils/getWeb3.js
+++ b/src/utils/getWeb3.js
@@ -1,38 +1,36 @@
 import Web3 from 'web3'
 
-let getWeb3 = new Promise(function(resolve, reject) {
-  // Wait for loading completion to avoid race conditions with web3 injection timing.
-  window.addEventListener('load', function() {
-    var results
-    var web3 = window.web3
+const getInjectedWeb3 = () => {
+  if (typeof window === 'undefined') {
+    throw new Error('Window object is unavailable.');
+  }
 
-    // Checking if Web3 has been injected by the browser (Mist/MetaMask)
-    if (typeof web3 !== 'undefined') {
-      // Use Mist/MetaMask's provider.
-      web3 = new Web3(web3.currentProvider)
+  if (window.ethereum) {
+    return new Web3(window.ethereum);
+  }
 
-      results = {
-        web3: web3
-      }
+  if (window.web3 && window.web3.currentProvider) {
+    return new Web3(window.web3.currentProvider);
+  }
 
-      console.log('Injected web3 detected.');
+  return new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
+};
 
-      resolve(results)
-    } else {
-      // Fallback to localhost if no web3 injection.
-      var provider = new Web3.providers.HttpProvider('http://localhost:8545')
-
-      web3 = new Web3(provider)
-
-      results = {
-        web3: web3
-      }
-
-      console.log('No web3 instance injected, using Local web3.');
-
-      resolve(results)
+const getWeb3 = new Promise((resolve, reject) => {
+  const initializeWeb3 = () => {
+    try {
+      resolve({ web3: getInjectedWeb3() });
+    } catch (error) {
+      reject(error);
     }
-  })
-})
+  };
+
+  if (document.readyState === 'complete') {
+    initializeWeb3();
+    return;
+  }
+
+  window.addEventListener('load', initializeWeb3);
+});
 
 export default getWeb3


### PR DESCRIPTION
### Motivation

- Replace legacy web3 injection code to support modern providers (`window.ethereum`) and robustly fallback to local RPC.  
- Improve application resilience and UX by adding loading states, clearer error/success messages, and safer event watcher cleanup.  
- Update project documentation to provide clearer local development and testing instructions.

### Description

- Rewrote `src/utils/getWeb3.js` to detect `window.ethereum` and `window.web3`, initialize a `Web3` instance reliably, and initialize on document ready.  
- Updated `src/App.js` to initialize web3 in `componentDidMount`, pass the provider when instantiating the contract, add `loadingContract` state, set the active `account`, and surface initialization errors via `message`.  
- Hardened components: `src/components/Common.js` now tracks watchers in an array and safely stops them on unmount, and uses `web3.fromWei(..., 'ether').toString(10)`; `src/components/Employee.js` (renamed/fixed) adds a loading flow, error handling, and balance display fixes; `src/components/EmployeeList.js` adds controlled form inputs, immutable state updates, improved async error handling, and renders actions as buttons; `src/components/Fund.js` adds a `submitting` state and success/error messages; `src/components/Employer.js` adds owner-check error handling and a default render case.  
- Overhauled `README.md` with a concise project structure, prerequisites, local development steps, best-practice notes, and explicit testing commands including `npm test` and `truffle test`.

### Testing

- Ran frontend unit tests with `npm test -- --watch=false`, which completed successfully.  
- Ran smart contract tests with `truffle test` against a local Ganache instance, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b67433d4832c86f581f190b358a9)